### PR TITLE
CLI command improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ const response = await fetch('google.com');
   Run the following command, replacing `<hostname>` with your server's hostname.
   
   ```sh
-  openssl s_client -servername <hostname> -connect <hostname>:443 | openssl x509 -pubkey -noout | openssl rsa -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
+  echo | openssl s_client -servername <hostname> -connect <hostname>:443 2>/dev/null | openssl x509 -pubkey -noout | openssl pkey -pubin -outform DER | openssl dgst -sha256 -binary | openssl enc -base64
   ```
   
   #### Certificate file


### PR DESCRIPTION
The previous CLI command only works with RSA certificates. This proposed version also ignores STDERR and doesn't "hang" forever.