### PR TITLE
fix: add type for turbomodules spec

### DIFF
--- a/src/NativeSslPublicKeyPinning.ts
+++ b/src/NativeSslPublicKeyPinning.ts
@@ -1,7 +1,7 @@
 import { TurboModuleRegistry, type TurboModule } from 'react-native';
 
 export interface Spec extends TurboModule {
-  initialize(options: {}): Promise<void>;
+  initialize(options: {[key: string]: {}}): Promise<void>;
   disable(): Promise<void>;
 
   addListener: (eventType: string) => void;

--- a/src/NativeSslPublicKeyPinning.ts
+++ b/src/NativeSslPublicKeyPinning.ts
@@ -1,7 +1,7 @@
 import { TurboModuleRegistry, type TurboModule } from 'react-native';
 
 export interface Spec extends TurboModule {
-  initialize(options: {[key: string]: {}}): Promise<void>;
+  initialize(options: { [key: string]: {} }): Promise<void>;
   disable(): Promise<void>;
 
   addListener: (eventType: string) => void;


### PR DESCRIPTION
THis allows to create a prope Objective-c type with new Architecture.

Fix #327 