### PR TITLE
fix: prevent errors upon importing module while native library is not available

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -107,6 +107,9 @@ export default function App() {
   }, [testDomain]);
 
   React.useEffect(() => {
+    if (!isSslPinningAvailable()) {
+      return;
+    }
     const subscription = addSslPinningErrorListener((error) => {
       setPinningError(`Pinning Error: ${error.serverHostname}`);
     });

--- a/src/NativeSslPublicKeyPinning.ts
+++ b/src/NativeSslPublicKeyPinning.ts
@@ -8,6 +8,4 @@ export interface Spec extends TurboModule {
   removeListeners: (count: number) => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>(
-  'SslPublicKeyPinning'
-) as Spec | null;
+export default TurboModuleRegistry.get<Spec>('SslPublicKeyPinning');


### PR DESCRIPTION
Closes #457 